### PR TITLE
WIP: Support multiple CSV formats through configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -134,3 +134,6 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# OS specific
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ https://docs.gspread.org/en/latest/oauth2.html#for-bots-using-service-account).
     If you use my template, these are already correct if you change the name of the spreadsheet to "Finances".
 6. Don't forget to add the "client_secret.json" file to the same folder.
 7. Download your transaction data as CSV (for example: *NLXXINGBXXXXXXXXXX_01-01-2011_02-07-2020.csv*)
-    - Currently the only working bank is [ING](https://www.ing.nl/). If you want to make it work with your bank,
-    please send me a file with the format your bank uses so I can include it as an option.
+    - Currently the only working banks are [ING](https://www.ing.nl/) and [ASN](https://www.asnbank.nl/). If you want to make it work with your bank, please send me a file with the format your bank uses so I can include it as an option.
 8. Run **personal_finance** in your terminal and checkout the result.
+
+## Creating a new CSV Config
+Based on the `CsvConfig` dataclass in `__main__.py` you can create a new CSV config for a different bank. Add it to the `csv_configs` directory and select it when running the program. Examples and default configs can be found in this folder already.

--- a/csv_configs/asn.yaml
+++ b/csv_configs/asn.yaml
@@ -5,7 +5,7 @@ amount_decimal_delimiter: "."
 name_description_col: name
 notification_col: notification
 delimiter: ","
-columns_names:
+column_names:
 - date
 - iban
 - contra iban

--- a/csv_configs/asn.yaml
+++ b/csv_configs/asn.yaml
@@ -1,0 +1,27 @@
+date_col: date
+date_format: "%d-%m-%Y"
+amount_col: amount
+amount_decimal_delimiter: "."
+name_description_col: name
+notification_col: notification
+delimiter: ","
+columns_names:
+- date
+- iban
+- contra iban
+- name
+- empty 0
+- empty 1
+- empty 2
+- currency 0
+- balance
+- currency
+- amount
+- date 1
+- date 2
+- code
+- type
+- code 1
+- reference
+- notification
+- number

--- a/csv_configs/ing.yaml
+++ b/csv_configs/ing.yaml
@@ -1,0 +1,9 @@
+date_col: Datum
+date_format: "%Y%m%d"
+amount_col: Bedrag (EUR)
+amount_decimal_separator: ","
+debit_credit_col: Af Bij
+debit: Af
+credit: Bij
+name_description_col: Naam / Omschrijving
+notification_col: Mededelingen

--- a/csv_configs/ing.yaml
+++ b/csv_configs/ing.yaml
@@ -1,9 +1,10 @@
 date_col: Datum
 date_format: "%Y%m%d"
 amount_col: Bedrag (EUR)
-amount_decimal_separator: ","
+amount_decimal_delimiter: ","
 debit_credit_col: Af Bij
 debit: Af
 credit: Bij
 name_description_col: Naam / Omschrijving
 notification_col: Mededelingen
+delimiter: ","

--- a/personal_finance/__main__.py
+++ b/personal_finance/__main__.py
@@ -49,7 +49,7 @@ class CsvConfig:
     # Delimiter of the CSV file itself
     delimiter: str = ","
     # Optional custom column names if the CSV has no header row
-    columns_names: List[str] = None
+    column_names: List[str] = None
 
 
 def personal_finance():
@@ -146,7 +146,7 @@ def load_bank_file(file: str, csv_config: CsvConfig) -> pd.DataFrame:
     data (DataFrame)
         All bank data neatly converted to a DataFrame to be used by the program.
     """
-    df = pd.read_csv(file, delimiter=csv_config.delimiter, names=csv_config.columns_names)
+    df = pd.read_csv(file, delimiter=csv_config.delimiter, names=csv_config.column_names)
 
     df[csv_config.amount_col] = (
         df[csv_config.amount_col].astype(str).str.replace(csv_config.amount_decimal_delimiter, ".", regex=False)
@@ -167,7 +167,7 @@ def load_bank_file(file: str, csv_config: CsvConfig) -> pd.DataFrame:
     return df.set_index(date)
 
 
-def load_personal_input(spreadsheet, sheet):
+def load_personal_input(spreadsheet: gspread.Spreadsheet, sheet: str):
     """
     Description
     ----
@@ -197,7 +197,7 @@ def load_personal_input(spreadsheet, sheet):
     return input_data.replace('', np.nan)
 
 
-def category_selector(bank_data: pd.DataFrame, input_data: pd.DataFrame, csv_config: CsvConfig) -> pd.DataFrame:
+def category_selector(bank_data: pd.DataFrame, input_data: pd.DataFrame, csv_config: CsvConfig):
     """
     Description
     ----
@@ -237,7 +237,7 @@ def category_selector(bank_data: pd.DataFrame, input_data: pd.DataFrame, csv_con
     return new_bank_data
 
 
-def write_to_spreadsheet(bank_data, spreadsheet, sheet):
+def write_to_spreadsheet(bank_data: pd.DataFrame, spreadsheet: gspread.Spreadsheet, sheet: str):
     """
     Description
     ----


### PR DESCRIPTION
Changed the setup so new CSV formats can be added with a simple configuration file. It is still work in progress, but I managed to get it to work with a CSV from ASN bank as well.

The `CsvConfig` dataclass explains what is required for a CSV configuration. The ASN export directly was a special case, since it doesn't come with a header row. Therefore, you can add `column_names`. The rest of it is pretty straightforward: for any column we need to know, you give the name and sometimes some extra info like delimiters or a format.

Still needs some work on the user interaction (you have to specify the format every time) and needs to be verified with more CSV formats. And probably some typos here and there.